### PR TITLE
Fix github actions after renaming default branch

### DIFF
--- a/.github/workflows/ci-commit.yml
+++ b/.github/workflows/ci-commit.yml
@@ -3,7 +3,7 @@ name: CI - commit
 on:
   push:
     branches-ignore:
-      - main
+      - master
 
 jobs:
   build:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,9 +1,9 @@
-name: CI - main
+name: CI - master
 
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: main
+          ref: master
 
       - name: Set up JDK 21
         uses: actions/setup-java@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref_name, 'hotfix')
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref_name, 'hotfix')
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated CI workflows to trigger on the "master" branch instead of "main".
	- Renamed CI workflow from "CI - main" to "CI - master".
  
- **Bug Fixes**
	- Adjusted release job conditions to execute based on the "master" branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->